### PR TITLE
Feature #366 develop single_sq_project

### DIFF
--- a/.github/jobs/configure_sonarqube.sh
+++ b/.github/jobs/configure_sonarqube.sh
@@ -47,9 +47,7 @@ fi
 
 # Configure the sonar-project.properties
 [ -e $SONAR_PROPERTIES ] && rm $SONAR_PROPERTIES
-sed -e "s|SONAR_PROJECT_KEY|METcalcpy-GHA|" \
-    -e "s|SONAR_PROJECT_NAME|METcalcpy GHA|" \
-    -e "s|SONAR_PROJECT_VERSION|$SONAR_PROJECT_VERSION|" \
+sed -e "s|SONAR_PROJECT_VERSION|$SONAR_PROJECT_VERSION|" \
     -e "s|SONAR_HOST_URL|$SONAR_HOST_URL|" \
     -e "s|SONAR_TOKEN|$SONAR_TOKEN|" \
     -e "s|SONAR_BRANCH_NAME|$SOURCE_BRANCH|" \

--- a/internal/scripts/sonarqube/run_sonarqube.sh
+++ b/internal/scripts/sonarqube/run_sonarqube.sh
@@ -118,9 +118,7 @@ SONAR_PROPERTIES=sonar-project.properties
 
 # Configure the sonar-project.properties
 [ -e $SONAR_PROPERTIES ] && rm $SONAR_PROPERTIES
-sed -e "s|SONAR_PROJECT_KEY|METcalcpy_NB|" \
-    -e "s|SONAR_PROJECT_NAME|METcalcpy Nightly Build|" \
-    -e "s|SONAR_PROJECT_VERSION|$SONAR_PROJECT_VERSION|" \
+sed -e "s|SONAR_PROJECT_VERSION|$SONAR_PROJECT_VERSION|" \
     -e "s|SONAR_HOST_URL|$SONAR_HOST_URL|" \
     -e "s|SONAR_TOKEN|$SONAR_TOKEN|" \
     -e "s|SONAR_BRANCH_NAME|${1}|" \

--- a/internal/scripts/sonarqube/sonar-project.properties
+++ b/internal/scripts/sonarqube/sonar-project.properties
@@ -1,6 +1,6 @@
 # Project and source code settings
-sonar.projectKey=SONAR_PROJECT_KEY
-sonar.projectName=SONAR_PROJECT_NAME
+sonar.projectKey=METcalcpy
+sonar.projectName=METcalcpy
 sonar.projectVersion=SONAR_PROJECT_VERSION
 sonar.branch.name=SONAR_BRANCH_NAME
 sonar.sources=metcalcpy,scratch,test


### PR DESCRIPTION
Same as changes described in PR https://github.com/dtcenter/MET/pull/2865, but for the METcalcpy develop branch.

While https://github.com/dtcenter/METplus/issues/2544 describes using a custom action for METplus/plotpy/calcpy/dataio, I decided to propose this small change now while the details are still fresh.