### PR TITLE
Feature 360 mode csi

### DIFF
--- a/metcalcpy/util/mode_arearat_statistics.py
+++ b/metcalcpy/util/mode_arearat_statistics.py
@@ -902,16 +902,16 @@ def calculate_objacsi(input_data, columns_names):
 
     try:
         nominator_data = column_data_by_name_value(input_data, columns_names, nominator_filter)
-        nominator = sum_column_data_by_name(nominator_data, columns_names, 'area')
+        nominator = sum_column_data_by_name(nominator_data, columns_names, 'area') / 2
 
         denominator_1_data = \
             column_data_by_name_value(input_data, columns_names, denominator_filter_1)
-        denominator_1 = sum_column_data_by_name(denominator_1_data, columns_names, 'area')
+        denominator_1 = sum_column_data_by_name(denominator_1_data, columns_names, 'area') / 2
 
         denominator_2_data = \
             column_data_by_name_value(input_data, columns_names, denominator_filter_2)
         denominator_2 = sum_column_data_by_name(denominator_2_data, columns_names, 'area')
-        result = round_half_up(nominator / (denominator_1 + 2 * denominator_2), PRECISION)
+        result = round_half_up(nominator / (denominator_1 + denominator_2), PRECISION)
     except (TypeError, ZeroDivisionError, Warning, ValueError):
         result = None
     warnings.filterwarnings('ignore')

--- a/metcalcpy/util/mode_ratio_statistics.py
+++ b/metcalcpy/util/mode_ratio_statistics.py
@@ -838,17 +838,17 @@ def calculate_objcsi(input_data, columns_names):
             or None if some of the data values are missing or invalid
     """
     warnings.filterwarnings('error')
-    nominator_filter = {'fcst_flag': 1, 'matched_flag': 0}
+    nominator_filter = {'simple_flag': 1, 'matched_flag': 1}
     denominator_filter_1 = {'simple_flag': 1, 'matched_flag': 1}
     denominator_filter_2 = {'simple_flag': 1, 'matched_flag': 0}
 
     try:
-        nominator = nrow_column_data_by_name_value(input_data, columns_names, nominator_filter)
+        nominator = nrow_column_data_by_name_value(input_data, columns_names, nominator_filter) / 2
         denominator_1 = \
-            nrow_column_data_by_name_value(input_data, columns_names, denominator_filter_1)
+            nrow_column_data_by_name_value(input_data, columns_names, denominator_filter_1) / 2
         denominator_2 = \
             nrow_column_data_by_name_value(input_data, columns_names, denominator_filter_2)
-        result = round_half_up(nominator / (denominator_1 + 2 * denominator_2), PRECISION)
+        result = round_half_up(nominator / (denominator_1 +  denominator_2), PRECISION)
     except (TypeError, ZeroDivisionError, Warning, ValueError):
         result = None
     warnings.filterwarnings('ignore')

--- a/metcalcpy/util/mode_ratio_statistics.py
+++ b/metcalcpy/util/mode_ratio_statistics.py
@@ -848,7 +848,7 @@ def calculate_objcsi(input_data, columns_names):
             nrow_column_data_by_name_value(input_data, columns_names, denominator_filter_1) / 2
         denominator_2 = \
             nrow_column_data_by_name_value(input_data, columns_names, denominator_filter_2)
-        result = round_half_up(nominator / (denominator_1 +  denominator_2), PRECISION)
+        result = round_half_up(nominator / (denominator_1 + denominator_2), PRECISION)
     except (TypeError, ZeroDivisionError, Warning, ValueError):
         result = None
     warnings.filterwarnings('ignore')


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

-    updated METviewer development version on 'dakota' to use the changes made in METcalcpy for calculating the OBJCSI and OBJACSI (equations are consistent with the METviewer documentation and in the agg_stat_bootstrap.R code in METviewer)

- loaded the XML config file from the test used to test the METviewer changes in issue #561:
   - https://github.com/dtcenter/METviewer/pull/519
   
[plot_20240215_190637.xml.txt](https://github.com/user-attachments/files/16397260/plot_20240215_190637.xml.txt)


- Modified the run by selecting the 'Use python' under the Common menu
- Compared Y1 Points generated from the Python-generated plot to the plot_20240215_190637.points1 generated in the METviewer issue #561 testing:


From changes made to Rscript (METviewer issue #561):
[plot_20240215_190637.points1.txt](https://github.com/user-attachments/files/16397256/plot_20240215_190637.points1.txt)


From changes made to the METcalcpy equations:
```
0.944785 0.944785 0.944785
0.559420 0.559420 0.559420
```


- Compared the generated plot to the plot generated in testing for METviewer Issue #561:

R-script generated plot:
![plot_20240215_190637](https://github.com/user-attachments/assets/05133a59-95d4-4c52-896c-4274dfe44017)

Python script generated plot (i.e. with METcalcpy equation updates)

![plot_20240726_171317](https://github.com/user-attachments/assets/8f656dcf-e021-46ca-a54e-95496e0d18bf)

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- create any additional MODE CSI plots on the METviewer instance on 'dakota' and verify that the trends for the OBJCSI and OBJACSI plots are consistent with expected behavior.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[NA]**

- [x] Do these changes include sufficient testing updates? **[No]**

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **Earliest convenience**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METcalcpy-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
